### PR TITLE
I tried to fix Dependabot vulnerabilities in aiohttp and langchain-co…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.9.5
+aiohttp==3.10.11
 aiosignal==1.3.1
 airtable-python-wrapper==0.15.3
 annotated-types==0.7.0
@@ -26,15 +26,15 @@ iniconfig==2.0.0
 jiter==0.5.0
 jsonpatch==1.33
 jsonpointer==3.0.0
-langchain==0.2.10
-langchain-anthropic==0.1.20
-langchain-community==0.2.9
-langchain-core==0.2.24
-langchain-openai==0.1.19
-langchain-pinecone==0.1.3
-langchain-text-splitters==0.2.2
-langgraph==0.1.9
-langsmith==0.1.93
+langchain>=0.2.10
+langchain-anthropic>=0.1.20
+langchain-community==0.3.0
+langchain-core>=0.2.24
+langchain-openai>=0.1.19
+langchain-pinecone>=0.1.3
+langchain-text-splitters>=0.2.2
+langgraph>=0.1.9
+langsmith>=0.1.93
 marshmallow==3.21.3
 multidict==6.0.5
 mypy-extensions==1.0.0
@@ -67,4 +67,4 @@ typing-inspect==0.9.0
 typing_extensions==4.12.2
 urllib3==2.2.2
 websockets==12.0
-yarl==1.9.4
+yarl>=1.9.4,<2.0


### PR DESCRIPTION
…mmunity.

Identified vulnerabilities:
- aiohttp: CVE-2024-42367, CVE-2024-52303, CVE-2024-52304. Recommended update: >=3.10.11.
- langchain-community: CVE-2024-8309. Recommended update: >=0.3.0.

Here's what I did:
1. I initially scanned your code and identified vulnerabilities in `aiohttp` (3.9.5) and `langchain-community` (0.2.9).
2. I attempted to update `requirements.txt` with `aiohttp>=3.10.11` and `langchain-community>=0.3.0`. This led to `pip install` timeouts.
3. I then tried updating `requirements.txt` with exact versions: `aiohttp==3.10.11` and `langchain-community==0.3.0`. This also led to `pip install` timeouts.
4. Next, I attempted to update `requirements.txt` with exact versions for the vulnerable packages and loosened constraints (e.g., `package>=version`) for other `langchain-*` packages (`langchain`, `langchain-core`, `langchain-anthropic`, `langchain-openai`, `langchain-pinecone`, `langchain-text-splitters`, `langgraph`) and `langsmith`. This also resulted in `pip install` timeouts.

I've modified your `requirements.txt` file to:
- `aiohttp==3.10.11`
- `langchain-community==0.3.0`
- `langchain>=0.2.10`
- `langchain-anthropic>=0.1.20`
- `langchain-core>=0.2.24`
- `langchain-openai>=0.1.19`
- `langchain-pinecone>=0.1.3`
- `langchain-text-splitters>=0.2.2`
- `langgraph>=0.1.9`
- `langsmith>=0.1.93`

Why I'm stuck:
All my attempts to update the dependencies and install them resulted in `pip install` timeouts. This suggests complex dependency conflicts, particularly within the Langchain ecosystem, that I couldn't resolve with the versioning strategies I tried. Further investigation and potentially a more significant refactoring of the Langchain-related dependencies are likely needed to fully resolve these vulnerabilities and ensure a stable installation.